### PR TITLE
fixes for subrepo compilation

### DIFF
--- a/projects/rest-api-client-ng/subrepo.tsconfig.lib.json
+++ b/projects/rest-api-client-ng/subrepo.tsconfig.lib.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../out-tsc/lib",
+    "target": "es2015",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "declaration": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true
+  },
+  "exclude": [
+    "test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/projects/rest-api-client-ng/subrepo.tsconfig.spec.json
+++ b/projects/rest-api-client-ng/subrepo.tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

in order to compile from a parent project using this repository as a subrepo an additional tsconfig is necessary.

## Why was change needed

in order to compile from a parent project using this repository as a subrepo an additional tsconfig is necessary.

## What does change improve
subrepo compilation
