### PR TITLE
#63 added 'additionalHeaders' parameter to methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2021-06-08
+
+- Dependency security updates and bugfixes.
+- Added new `additionalHeaders` parameter to _*ALL*_ service methods. see issue #63
+
 ## [2.2.1] - 2021-04-08
 
 - Dependency security updates and bugfixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/rest-api-client-ng",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A package providing restful http interfaces to typescript interfaces to @senzing/senzing-api-server. Utilizes the OpenAPI spec defined in the https://github.com/Senzing/senzing-rest-api-specification repository.",
   "scripts": {
     "ng": "ng",

--- a/projects/rest-api-client-ng/package.json
+++ b/projects/rest-api-client-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/rest-api-client-ng",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A package providing restful http interfaces to typescript interfaces to @senzing/senzing-api-server. Utilizes the OpenAPI spec defined in the https://github.com/Senzing/senzing-rest-api-specification repository.",
   "repository": {
     "type": "git",

--- a/projects/rest-api-client-ng/src/lib/api/admin.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/admin.service.ts
@@ -80,10 +80,10 @@ export class AdminService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getServerInfo(observe?: 'body', reportProgress?: boolean): Observable<SzServerInfoResponse>;
-    public getServerInfo(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzServerInfoResponse>>;
-    public getServerInfo(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzServerInfoResponse>>;
-    public getServerInfo(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getServerInfo(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzServerInfoResponse>;
+    public getServerInfo(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzServerInfoResponse>>;
+    public getServerInfo(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string} ): Observable<HttpEvent<SzServerInfoResponse>>;
+    public getServerInfo(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {}): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -96,6 +96,11 @@ export class AdminService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -118,10 +123,10 @@ export class AdminService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public heartbeat(observe?: 'body', reportProgress?: boolean): Observable<SzBaseResponse>;
-    public heartbeat(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzBaseResponse>>;
-    public heartbeat(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzBaseResponse>>;
-    public heartbeat(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public heartbeat(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzBaseResponse>;
+    public heartbeat(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzBaseResponse>>;
+    public heartbeat(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzBaseResponse>>;
+    public heartbeat(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -134,6 +139,11 @@ export class AdminService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -157,10 +167,10 @@ export class AdminService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public license(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzLicenseResponse>;
-    public license(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzLicenseResponse>>;
-    public license(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzLicenseResponse>>;
-    public license(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public license(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzLicenseResponse>;
+    public license(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzLicenseResponse>>;
+    public license(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzLicenseResponse>>;
+    public license(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -179,6 +189,11 @@ export class AdminService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -203,10 +218,10 @@ export class AdminService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public version(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzVersionResponse>;
-    public version(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzVersionResponse>>;
-    public version(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzVersionResponse>>;
-    public version(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public version(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzVersionResponse>;
+    public version(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzVersionResponse>>;
+    public version(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzVersionResponse>>;
+    public version(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -225,6 +240,11 @@ export class AdminService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header

--- a/projects/rest-api-client-ng/src/lib/api/admin.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/admin.service.ts
@@ -29,8 +29,10 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class AdminService {
+    protected _basePath     = '/';
+    public configuration    = new Configuration();
+    private _defaultHeaders = new HttpHeaders();
 
-    protected _basePath = '/';
     /**
      * get the basePath from the configuration instance
      * or alternatively fallback to local reference
@@ -44,10 +46,27 @@ export class AdminService {
     public set basePath(value: string) {
         this._basePath = value;
     }
-
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
-
+    /**
+     * get additional headers so we can add them to the default request headers
+     */
+    private get additionalHeaders(): {[key: string]: string} | undefined {
+        return this.configuration && this.configuration.additionalHeaders ? this.configuration.additionalHeaders : undefined;
+    }
+    /** 
+     * the default headers for http requests
+     * including any additional headers added to configuration
+    */
+    public get defaultHeaders() {
+        let retVal = this._defaultHeaders;
+        let _additionalHeaders = this.additionalHeaders;
+        // if additional headers specified merge with defaults
+        if(_additionalHeaders) {
+            for(let _hKey in _additionalHeaders) {
+                retVal = retVal.set(_hKey, _additionalHeaders[_hKey]);
+            }
+        }
+        return retVal;
+    }
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
         if (basePath) {
             this.basePath = basePath;

--- a/projects/rest-api-client-ng/src/lib/api/bulkData.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/bulkData.service.ts
@@ -67,10 +67,10 @@ export class BulkDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'body', reportProgress?: boolean): Observable<SzBulkDataAnalysisResponse>;
-    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzBulkDataAnalysisResponse>>;
-    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzBulkDataAnalysisResponse>>;
-    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzBulkDataAnalysisResponse>;
+    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzBulkDataAnalysisResponse>>;
+    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzBulkDataAnalysisResponse>>;
+    public analyzeBulkRecords(body: string | Blob | File | Array<{ [key: string]: any; }>, progressPeriod?: string, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling analyzeBulkRecords.');
@@ -113,6 +113,11 @@ export class BulkDataService {
         const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes, body);
         if(httpContentTypeSelected != undefined) {
             headers = headers.set('Content-Type', httpContentTypeSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         const canConsumeForm = this.canConsumeForm(consumes);
@@ -159,47 +164,16 @@ export class BulkDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'body', reportProgress?: boolean): Observable<SzBulkLoadResponse>;
-    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzBulkLoadResponse>>;
-    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzBulkLoadResponse>>;
-    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzBulkLoadResponse>;
+    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzBulkLoadResponse>>;
+    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzBulkLoadResponse>>;
+    public loadBulkRecords(body: string | Blob | File | Array<{ [key: string]: any }>, dataSource?: string, mapDataSources?: string, mapDataSource?: Array<string>, entityType?: string, mapEntityTypes?: string, mapEntityType?: Array<string>, progressPeriod?: string, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling loadBulkRecords.');
         }
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
-        /*
-        if (dataSource !== undefined && dataSource !== null) {
-          if((dataSource as { [key: string]: string }) && typeof (dataSource as { [key: string]: string }) !== 'string') {
-            for (const key in (dataSource as { [key: string]: string })) {
-                if(key === null || key === 'null' || key === 'NULL') {
-                  queryParameters = queryParameters.append('dataSource', dataSource[key]);
-                } else {
-                  queryParameters = queryParameters.append('dataSource_'+key, dataSource[key]);
-                }
-                //console.log('BulkDataService.loadBulkRecords entity types set to: ', queryParameters);
-            }
-          } else {
-            // is single ds
-            queryParameters = queryParameters.set('dataSource', <any>dataSource);
-          }
-      }
-
-      if (entityType !== undefined && entityType !== null) {
-        if((entityType as { [key: string]: string }) && typeof (entityType as { [key: string]: string }) !== 'string') {
-          for (const key in (entityType as { [key: string]: string })) {
-              if(key === null || key === 'null' || key === 'NULL') {
-                queryParameters = queryParameters.append('entityType', entityType[key]);
-              } else {
-                queryParameters = queryParameters.append('entityType_'+key, entityType[key]);
-              }
-          }
-        } else {
-          // is single et
-          queryParameters = queryParameters.set('entityType', <any>entityType);
-        }
-      }*/
 
         if (dataSource !== undefined && dataSource !== null) {
             queryParameters = queryParameters.set('dataSource', <any>dataSource);
@@ -238,6 +212,11 @@ export class BulkDataService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header

--- a/projects/rest-api-client-ng/src/lib/api/bulkData.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/bulkData.service.ts
@@ -29,10 +29,44 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class BulkDataService {
+    protected _basePath     = '/';
+    public configuration    = new Configuration();
+    private _defaultHeaders = new HttpHeaders();
 
-    protected basePath = '/';
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
+    /**
+     * get the basePath from the configuration instance
+     * or alternatively fallback to local reference
+     */
+    public get basePath(): string {
+        return this.configuration && this.configuration.basePath ? this.configuration.basePath : this._basePath;
+    }
+    /**
+     * set the local basePath reference
+     */
+    public set basePath(value: string) {
+        this._basePath = value;
+    }
+    /**
+     * get additional headers so we can add them to the default request headers
+     */
+    private get additionalHeaders(): {[key: string]: string} | undefined {
+        return this.configuration && this.configuration.additionalHeaders ? this.configuration.additionalHeaders : undefined;
+    }
+    /** 
+     * the default headers for http requests
+     * including any additional headers added to configuration
+    */
+    public get defaultHeaders() {
+        let retVal = this._defaultHeaders;
+        let _additionalHeaders = this.additionalHeaders;
+        // if additional headers specified merge with defaults
+        if(_additionalHeaders) {
+            for(let _hKey in _additionalHeaders) {
+                retVal = retVal.set(_hKey, _additionalHeaders[_hKey]);
+            }
+        }
+        return retVal;
+    }
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
         if (basePath) {

--- a/projects/rest-api-client-ng/src/lib/api/config.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/config.service.ts
@@ -41,8 +41,10 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class ConfigService {
+    protected _basePath     = '/';
+    public configuration    = new Configuration();
+    private _defaultHeaders = new HttpHeaders();
 
-    protected _basePath = '/';
     /**
      * get the basePath from the configuration instance
      * or alternatively fallback to local reference
@@ -56,8 +58,27 @@ export class ConfigService {
     public set basePath(value: string) {
         this._basePath = value;
     }
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
+    /**
+     * get additional headers so we can add them to the default request headers
+     */
+    private get additionalHeaders(): {[key: string]: string} | undefined {
+        return this.configuration && this.configuration.additionalHeaders ? this.configuration.additionalHeaders : undefined;
+    }
+    /** 
+     * the default headers for http requests
+     * including any additional headers added to configuration
+    */
+    public get defaultHeaders() {
+        let retVal = this._defaultHeaders;
+        let _additionalHeaders = this.additionalHeaders;
+        // if additional headers specified merge with defaults
+        if(_additionalHeaders) {
+            for(let _hKey in _additionalHeaders) {
+                retVal = retVal.set(_hKey, _additionalHeaders[_hKey]);
+            }
+        }
+        return retVal;
+    }
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
         if (basePath) {

--- a/projects/rest-api-client-ng/src/lib/api/config.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/config.service.ts
@@ -98,10 +98,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourcesResponse>;
-    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzDataSourcesResponse>>;
-    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzDataSourcesResponse>>;
-    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzDataSourcesResponse>;
+    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzDataSourcesResponse>>;
+    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzDataSourcesResponse>>;
+    public addDataSources(body?: Body | string, dataSource?: string | Array<string>, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
         if (dataSource && (dataSource as Array<string>).forEach) {
           (dataSource as Array<string>).forEach((element) => {
@@ -126,6 +126,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -163,10 +168,10 @@ See the various request body examples.
      * @param reportProgress flag to report request and response progress.
      */
     /*
-    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityClassesResponse>;
-    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityClassesResponse>>;
-    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityClassesResponse>>;
-    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityClassesResponse>;
+    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityClassesResponse>>;
+    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityClassesResponse>>;
+    public addEntityClasses(body?: Array<SzEntityClassDescriptor>, entityClass?: string, resolving?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -201,6 +206,11 @@ See the various request body examples.
         if (httpContentTypeSelected != undefined) {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         return this.httpClient.post<SzEntityClassesResponse>(`${this.basePath}/entity-classes`,
             body,
@@ -224,10 +234,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public addEntityTypes(body?: Body2 | string, entityType?: string | Array<string>, entityClass?: string, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -284,6 +294,11 @@ See the various request body examples.
         if (httpContentTypeSelected != undefined) {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         return this.httpClient.request<SzEntityTypesResponse>('post',`${this.basePath}/entity-types`,
             {
@@ -306,10 +321,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public addEntityTypesForClass(entityClassCode: string, body?: Array<SzEntityTypeDescriptor> | string, entityType?: Array<string>, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityClassCode === null || entityClassCode === undefined) {
             throw new Error('Required parameter entityClassCode was null or undefined when calling addEntityTypesForClass.');
@@ -365,6 +380,11 @@ See the various request body examples.
         if (httpContentTypeSelected != undefined) {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         return this.httpClient.request<SzEntityTypesResponse>('post',`${this.basePath}/entity-classes/${encodeURIComponent(String(entityClassCode))}/entity-types`,
             {
@@ -384,10 +404,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getActiveConfig(observe?: 'body', reportProgress?: boolean): Observable<SzConfigResponse>;
-    public getActiveConfig(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzConfigResponse>>;
-    public getActiveConfig(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzConfigResponse>>;
-    public getActiveConfig(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getActiveConfig(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzConfigResponse>;
+    public getActiveConfig(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzConfigResponse>>;
+    public getActiveConfig(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzConfigResponse>>;
+    public getActiveConfig(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -400,6 +420,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -424,10 +449,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzAttributeTypeResponse>;
-    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzAttributeTypeResponse>>;
-    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzAttributeTypeResponse>>;
-    public getAttributeType(attributeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzAttributeTypeResponse>;
+    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzAttributeTypeResponse>>;
+    public getAttributeType(attributeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzAttributeTypeResponse>>;
+    public getAttributeType(attributeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (attributeCode === null || attributeCode === undefined) {
             throw new Error('Required parameter attributeCode was null or undefined when calling getAttributeType.');
@@ -450,6 +475,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -477,10 +507,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzAttributeTypesResponse>;
-    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzAttributeTypesResponse>>;
-    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzAttributeTypesResponse>>;
-    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzAttributeTypesResponse>;
+    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzAttributeTypesResponse>>;
+    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzAttributeTypesResponse>>;
+    public getAttributeTypes(withInternal?: boolean, attributeClass?: SzAttributeClass, featureType?: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -512,6 +542,11 @@ See the various request body examples.
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -536,10 +571,10 @@ See the various request body examples.
      * @deprecated use getActiveConfig instead
      */
     /*
-    public getCurrentConfig(observe?: 'body', reportProgress?: boolean): Observable<SzConfigResponse>;
-    public getCurrentConfig(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzConfigResponse>>;
-    public getCurrentConfig(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzConfigResponse>>;
-    public getCurrentConfig(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getCurrentConfig(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzConfigResponse>;
+    public getCurrentConfig(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzConfigResponse>>;
+    public getCurrentConfig(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzConfigResponse>>;
+    public getCurrentConfig(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -552,6 +587,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -576,10 +616,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourceResponse>;
-    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzDataSourceResponse>>;
-    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzDataSourceResponse>>;
-    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzDataSourceResponse>;
+    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzDataSourceResponse>>;
+    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzDataSourceResponse>>;
+    public getDataSource(dataSourceCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling getDataSource.');
@@ -602,6 +642,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -626,10 +671,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getDataSources(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourcesResponse>;
-    public getDataSources(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzDataSourcesResponse>>;
-    public getDataSources(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzDataSourcesResponse>>;
-    public getDataSources(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getDataSources(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzDataSourcesResponse>;
+    public getDataSources(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzDataSourcesResponse>>;
+    public getDataSources(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzDataSourcesResponse>>;
+    public getDataSources(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -648,6 +693,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -673,10 +723,10 @@ See the various request body examples.
      * @deprecated not available as of 2.0.0. use getTemplateConfig() method instead.
      */
     /*
-    public getDefaultConfig(observe?: 'body', reportProgress?: boolean): Observable<SzConfigResponse>;
-    public getDefaultConfig(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzConfigResponse>>;
-    public getDefaultConfig(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzConfigResponse>>;
-    public getDefaultConfig(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getDefaultConfig(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzConfigResponse>;
+    public getDefaultConfig(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzConfigResponse>>;
+    public getDefaultConfig(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzConfigResponse>>;
+    public getDefaultConfig(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -689,6 +739,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -714,10 +769,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityClassResponse>;
-    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityClassResponse>>;
-    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityClassResponse>>;
-    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityClassResponse>;
+    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityClassResponse>>;
+    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityClassResponse>>;
+    public getEntityClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityClassCode === null || entityClassCode === undefined) {
             throw new Error('Required parameter entityClassCode was null or undefined when calling getEntityClass.');
@@ -740,6 +795,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -764,10 +824,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityClasses(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityClassesResponse>;
-    public getEntityClasses(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityClassesResponse>>;
-    public getEntityClasses(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityClassesResponse>>;
-    public getEntityClasses(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityClasses(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityClassesResponse>;
+    public getEntityClasses(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityClassesResponse>>;
+    public getEntityClasses(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityClassesResponse>>;
+    public getEntityClasses(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -786,6 +846,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -811,10 +876,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypeResponse>;
-    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypeResponse>>;
-    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypeResponse>>;
-    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypeResponse>;
+    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypeResponse>>;
+    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypeResponse>>;
+    public getEntityType(entityTypeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityTypeCode === null || entityTypeCode === undefined) {
             throw new Error('Required parameter entityTypeCode was null or undefined when calling getEntityType.');
@@ -837,6 +902,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -863,10 +933,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypeResponse>;
-    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypeResponse>>;
-    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypeResponse>>;
-    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypeResponse>;
+    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypeResponse>>;
+    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypeResponse>>;
+    public getEntityTypeByClass(entityClassCode: string, entityTypeCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityClassCode === null || entityClassCode === undefined) {
             throw new Error('Required parameter entityClassCode was null or undefined when calling getEntityTypeByClass.');
@@ -894,6 +964,11 @@ See the various request body examples.
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -918,10 +993,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public getEntityTypes(entityClass?: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -944,6 +1019,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -969,10 +1049,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public getEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityClassCode === null || entityClassCode === undefined) {
             throw new Error('Required parameter entityClassCode was null or undefined when calling getEntityTypesByClass.');
@@ -996,6 +1076,11 @@ See the various request body examples.
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -1018,10 +1103,10 @@ See the various request body examples.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getTemplateConfig(observe?: 'body', reportProgress?: boolean): Observable<SzConfigResponse>;
-    public getTemplateConfig(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzConfigResponse>>;
-    public getTemplateConfig(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzConfigResponse>>;
-    public getTemplateConfig(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getTemplateConfig(observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzConfigResponse>;
+    public getTemplateConfig(observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzConfigResponse>>;
+    public getTemplateConfig(observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzConfigResponse>>;
+    public getTemplateConfig(observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -1034,6 +1119,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -1058,10 +1148,10 @@ See the various request body examples.
      * @param reportProgress flag to report request and response progress.
      */
     /*
-    public listDataSources(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourcesResponse>;
-    public listDataSources(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzDataSourcesResponse>>;
-    public listDataSources(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzDataSourcesResponse>>;
-    public listDataSources(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public listDataSources(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzDataSourcesResponse>;
+    public listDataSources(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzDataSourcesResponse>>;
+    public listDataSources(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzDataSourcesResponse>>;
+    public listDataSources(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -1080,6 +1170,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -1105,10 +1200,10 @@ See the various request body examples.
      * @param reportProgress flag to report request and response progress.
      */
     /*
-    public listEntityClasses(withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityClassesResponse>;
-    public listEntityClasses(withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityClassesResponse>>;
-    public listEntityClasses(withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityClassesResponse>>;
-    public listEntityClasses(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public listEntityClasses(withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityClassesResponse>;
+    public listEntityClasses(withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityClassesResponse>>;
+    public listEntityClasses(withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityClassesResponse>>;
+    public listEntityClasses(withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
@@ -1127,6 +1222,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -1153,10 +1253,10 @@ See the various request body examples.
      * @param reportProgress flag to report request and response progress.
      */
     /*
-    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public listEntityTypes(entityClass?: SzAttributeClass, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -1179,6 +1279,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -1205,10 +1310,10 @@ See the various request body examples.
      * @param reportProgress flag to report request and response progress.
      */
     /*
-    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponse>;
-    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityTypesResponse>>;
-    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityTypesResponse>>;
-    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityTypesResponse>;
+    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityTypesResponse>>;
+    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityTypesResponse>>;
+    public listEntityTypesByClass(entityClassCode: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityClassCode === null || entityClassCode === undefined) {
             throw new Error('Required parameter entityClassCode was null or undefined when calling listEntityTypesByClass.');
@@ -1231,6 +1336,11 @@ See the various request body examples.
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header

--- a/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
@@ -35,7 +35,9 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class EntityDataService {
-    protected _basePath = '/';
+    protected _basePath     = '/';
+    public configuration    = new Configuration();
+    private _defaultHeaders = new HttpHeaders();
     /**
      * get the basePath from the configuration instance
      * or alternatively fallback to local reference
@@ -49,9 +51,27 @@ export class EntityDataService {
     public set basePath(value: string) {
         this._basePath = value;
     }
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
-
+    /**
+     * get additional headers so we can add them to the default request headers
+     */
+    private get additionalHeaders(): {[key: string]: string} | undefined {
+        return this.configuration && this.configuration.additionalHeaders ? this.configuration.additionalHeaders : undefined;
+    }
+    /** 
+     * the default headers for http requests
+     * including any additional headers added to configuration
+    */
+    public get defaultHeaders() {
+        let retVal = this._defaultHeaders;
+        let _additionalHeaders = this.additionalHeaders;
+        // if additional headers specified merge with defaults
+        if(_additionalHeaders) {
+            for(let _hKey in _additionalHeaders) {
+                retVal = retVal.set(_hKey, _additionalHeaders[_hKey]);
+            }
+        }
+        return retVal;
+    }
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
         if (basePath) {
             this.basePath = basePath;

--- a/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
@@ -89,10 +89,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzLoadRecordResponse>;
-    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzLoadRecordResponse>>;
-    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzLoadRecordResponse>>;
-    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzLoadRecordResponse>;
+    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzLoadRecordResponse>>;
+    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzLoadRecordResponse>>;
+    public addRecord(body: { [key: string]: any; }, dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling addRecord.');
@@ -132,6 +132,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -166,10 +171,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzLoadRecordResponse>;
-    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzLoadRecordResponse>>;
-    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzLoadRecordResponse>>;
-    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzLoadRecordResponse>;
+    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzLoadRecordResponse>>;
+    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzLoadRecordResponse>>;
+    public addRecordWithReturnedRecordId(body: { [key: string]: any; }, dataSourceCode: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling addRecordWithReturnedRecordId.');
@@ -215,6 +220,11 @@ export class EntityDataService {
         if (httpContentTypeSelected != undefined) {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         return this.httpClient.request<SzLoadRecordResponse>('post',`${this.basePath}/data-sources/${encodeURIComponent(String(dataSourceCode))}/records`,
             {
@@ -239,10 +249,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDeleteRecordResponse>;
-    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzDeleteRecordResponse>>;
-    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzDeleteRecordResponse>>;
-    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzDeleteRecordResponse>;
+    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzDeleteRecordResponse>>;
+    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzDeleteRecordResponse>>;
+    public deleteRecord(dataSourceCode: string, recordId: string, loadId?: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling deleteRecord.');
@@ -277,6 +287,11 @@ export class EntityDataService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header
@@ -335,6 +350,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -364,10 +384,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
     */
-    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityResponse>;
-    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityResponse>>;
-    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityResponse>>;
-    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityResponse>;
+    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityResponse>>;
+    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityResponse>>;
+    public getEntityByEntityId(entityId: number, featureMode?: SzFeatureMode, forceMinimal?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityId === null || entityId === undefined) {
             throw new Error('Required parameter entityId was null or undefined when calling getEntityByEntityId.');
@@ -411,6 +431,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -441,10 +466,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityResponse>;
-    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityResponse>>;
-    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityResponse>>;
-    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityResponse>;
+    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityResponse>>;
+    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityResponse>>;
+    public getEntityByRecordId(dataSourceCode: string, recordId: string, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelated?: SzRelationshipMode, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling getEntityByRecordId.');
@@ -492,6 +517,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -517,10 +547,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzRecordResponse>;
-    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzRecordResponse>>;
-    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzRecordResponse>>;
-    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzRecordResponse>;
+    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzRecordResponse>>;
+    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzRecordResponse>>;
+    public getRecord(dataSourceCode: string, recordId: string, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling getRecord.');
@@ -548,6 +578,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -573,10 +608,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzReevaluateResponse>;
-    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzReevaluateResponse>>;
-    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzReevaluateResponse>>;
-    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzReevaluateResponse>;
+    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzReevaluateResponse>>;
+    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzReevaluateResponse>>;
+    public reevaluateEntity(entityId: number, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityId === null || entityId === undefined) {
             throw new Error('Required parameter entityId was null or undefined when calling reevaluateEntity.');
@@ -607,6 +642,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -633,10 +673,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzReevaluateResponse>;
-    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzReevaluateResponse>>;
-    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzReevaluateResponse>>;
-    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzReevaluateResponse>;
+    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzReevaluateResponse>>;
+    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzReevaluateResponse>>;
+    public reevaluateRecord(dataSourceCode: string, recordId: string, withInfo?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling reevaluateRecord.');
@@ -668,6 +708,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -698,10 +743,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzAttributeSearchResponse>;
-    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzAttributeSearchResponse>>;
-    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzAttributeSearchResponse>>;
-    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzAttributeSearchResponse>;
+    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzAttributeSearchResponse>>;
+    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzAttributeSearchResponse>>;
+    public searchByAttributes(attrs?: string, attr?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRelationships?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -751,6 +796,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -780,10 +830,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzWhyEntityResponse>;
-    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzWhyEntityResponse>>;
-    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzWhyEntityResponse>>;
-    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzWhyEntityResponse>;
+    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzWhyEntityResponse>>;
+    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzWhyEntityResponse>>;
+    public whyEntityByEntityID(entityId: number, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (entityId === null || entityId === undefined) {
             throw new Error('Required parameter entityId was null or undefined when calling whyEntityByEntityID.');
@@ -827,6 +877,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -857,10 +912,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzWhyEntityResponse>;
-    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzWhyEntityResponse>>;
-    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzWhyEntityResponse>>;
-    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzWhyEntityResponse>;
+    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzWhyEntityResponse>>;
+    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzWhyEntityResponse>>;
+    public whyEntityByRecordID(dataSourceCode: string, recordId: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSourceCode === null || dataSourceCode === undefined) {
             throw new Error('Required parameter dataSourceCode was null or undefined when calling whyEntityByRecordID.');
@@ -908,6 +963,11 @@ export class EntityDataService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -940,10 +1000,10 @@ export class EntityDataService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzWhyRecordsResponse>;
-    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzWhyRecordsResponse>>;
-    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzWhyRecordsResponse>>;
-    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzWhyRecordsResponse>;
+    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzWhyRecordsResponse>>;
+    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzWhyRecordsResponse>>;
+    public whyRecords(dataSource1: string, recordId1: string, dataSource2: string, recordId2: string, withRelationships?: boolean, withFeatureStats?: boolean, withInternalFeatures?: boolean, featureMode?: SzFeatureMode, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (dataSource1 === null || dataSource1 === undefined) {
             throw new Error('Required parameter dataSource1 was null or undefined when calling whyRecords.');
@@ -1010,6 +1070,11 @@ export class EntityDataService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header

--- a/projects/rest-api-client-ng/src/lib/api/entityGraph.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/entityGraph.service.ts
@@ -30,8 +30,9 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class EntityGraphService {
-
-    protected _basePath = '/';
+    protected _basePath     = '/';
+    public configuration    = new Configuration();
+    private _defaultHeaders = new HttpHeaders();
     /**
      * get the basePath from the configuration instance
      * or alternatively fallback to local reference
@@ -45,10 +46,27 @@ export class EntityGraphService {
     public set basePath(value: string) {
         this._basePath = value;
     }
-
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
-
+    /**
+     * get additional headers so we can add them to the default request headers
+     */
+    private get additionalHeaders(): {[key: string]: string} | undefined {
+        return this.configuration && this.configuration.additionalHeaders ? this.configuration.additionalHeaders : undefined;
+    }
+    /** 
+     * the default headers for http requests
+     * including any additional headers added to configuration
+    */
+    public get defaultHeaders() {
+        let retVal = this._defaultHeaders;
+        let _additionalHeaders = this.additionalHeaders;
+        // if additional headers specified merge with defaults
+        if(_additionalHeaders) {
+            for(let _hKey in _additionalHeaders) {
+                retVal = retVal.set(_hKey, _additionalHeaders[_hKey]);
+            }
+        }
+        return retVal;
+    }
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
         if (basePath) {
             this.basePath = basePath;

--- a/projects/rest-api-client-ng/src/lib/api/entityGraph.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/entityGraph.service.ts
@@ -90,10 +90,10 @@ export class EntityGraphService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityNetworkResponse>;
-    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityNetworkResponse>>;
-    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityNetworkResponse>>;
-    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityNetworkResponse>;
+    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityNetworkResponse>>;
+    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityNetworkResponse>>;
+    public findEntityNetwork(e?: Array<SzEntityIdentifier>, entities?: SzEntityIdentifiers, maxDegrees?: number, buildOut?: number, maxEntities?: number, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
 
 
@@ -151,6 +151,11 @@ export class EntityGraphService {
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
+        }
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -185,10 +190,10 @@ export class EntityGraphService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityPathResponse>;
-    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<SzEntityPathResponse>>;
-    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<SzEntityPathResponse>>;
-    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
+    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'body', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<SzEntityPathResponse>;
+    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'response', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpResponse<SzEntityPathResponse>>;
+    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe?: 'events', reportProgress?: boolean, additionalHeaders?: {[key: string]: string}): Observable<HttpEvent<SzEntityPathResponse>>;
+    public findEntityPath(from: SzEntityIdentifier, to: SzEntityIdentifier, maxDegrees?: number, x?: Array<SzEntityIdentifier>, avoidEntities?: SzEntityIdentifiers, forbidAvoided?: boolean, s?: Array<string>, featureMode?: SzFeatureMode, withFeatureStats?: boolean, withInternalFeatures?: boolean, forceMinimal?: boolean, withRaw?: boolean, observe: any = 'body', reportProgress: boolean = false, additionalHeaders: {[key: string]: string} = {} ): Observable<any> {
 
         if (from === null || from === undefined) {
             throw new Error('Required parameter from was null or undefined when calling findPathByEntityID.');
@@ -261,6 +266,11 @@ export class EntityGraphService {
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         if (httpHeaderAcceptSelected != undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+        if(additionalHeaders) {
+            for(let _hKey in additionalHeaders) {
+                headers = headers.set(_hKey, additionalHeaders[_hKey]);
+            }
         }
 
         // to determine the Content-Type header


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #63 

## Why was change needed

To facilitate the _option_ for implementations to pass additional HTTP headers to API Server endpoints.

## What does change improve

Passing additional or custom headers are necessary in certain operation scenario's, ie: passing `X-Amz-Security-Token` to a [Cognito](https://aws.amazon.com/cognito/) enabled [API Gateway](https://aws.amazon.com/api-gateway/) address after user authentication.
