### PR TITLE
Bugfix for object parameter encoding in getVirtualEntityByRecordIds

### DIFF
--- a/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
+++ b/projects/rest-api-client-ng/src/lib/api/entityData.service.ts
@@ -38,6 +38,7 @@ import { SzWhyRecordsResponse } from '../model/szWhyRecordsResponse';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { SzRecordId } from '../model/models';
 
 
 @Injectable()
@@ -602,6 +603,10 @@ export class EntityDataService {
         let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
         if (r) {
             r.forEach((element) => {
+                // SzRecordIdentifier can be object or string
+                if(element && (element as SzRecordId).id){
+                    element = JSON.stringify(element);
+                }
                 queryParameters = queryParameters.append('r', <any>element);
             })
         }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #155 

## Why was change needed

The value of SzRecordIdentifier can be both a : delimited string OR a object({src: string, id: string}). The parameter for the How api method getVirtualEntityByRecordIds takes an array of SzRecordIdentifier but does not bother to detect whether or not the value is an object. If you pass an array of objects it encodes them in the query string as {object object}

